### PR TITLE
Fix XSeries initialization error on Luminol 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     }
     implementation("org.bstats:bstats-bukkit:3.2.1")
     implementation("com.github.technicallycoded:FoliaLib:0.4.4")
-    implementation("com.github.cryptomorin:XSeries:v13.6.0")
+    implementation("com.github.cryptomorin:XSeries:13.7.0")
     implementation("de.tr7zw:item-nbt-api:2.15.7")
     compileOnly(files("libs/RoseStacker-1.5.22.jar"))
 }


### PR DESCRIPTION
When running Surf v5.0.0 on Luminol 26.1.2, an ExceptionInInitializerError occurs in XMaterial (full log: https://mclo.gs/M9cH7Q1). This is caused by an outdated XSeries dependency that doesn't properly support Folia-based servers like Luminol.

Updated XSeries to a newer version. Tested and verified working on my Luminol 26.1.2 servers.